### PR TITLE
Update virtualScroll.component.ts

### DIFF
--- a/src/virtualScroll.component.ts
+++ b/src/virtualScroll.component.ts
@@ -6,6 +6,8 @@ import {
   ViewContainerRef, NgZone
 } from '@angular/core';
 
+// test
+
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import {animationFrame as animationScheduler} from 'rxjs/scheduler/animationFrame';

--- a/src/virtualScroll.component.ts
+++ b/src/virtualScroll.component.ts
@@ -6,8 +6,6 @@ import {
   ViewContainerRef, NgZone
 } from '@angular/core';
 
-// test
-
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import {animationFrame as animationScheduler} from 'rxjs/scheduler/animationFrame';

--- a/src/virtualScroll.component.ts
+++ b/src/virtualScroll.component.ts
@@ -2,11 +2,12 @@ import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component,
   ComponentFactory, ComponentFactoryResolver, ContentChild,
   ElementRef, Input, OnDestroy, OnInit,
-  Renderer, TemplateRef, ViewChild,
-  ViewContainerRef
+  TemplateRef, ViewChild,
+  ViewContainerRef, NgZone
 } from '@angular/core';
 
 import {Observable} from 'rxjs/Observable';
+import {Subject} from 'rxjs/Subject';
 import {animationFrame as animationScheduler} from 'rxjs/scheduler/animationFrame';
 import {Subscription} from 'rxjs/Subscription';
 
@@ -85,7 +86,8 @@ export class VirtualScrollComponent implements OnInit, OnDestroy {
 
   constructor(
     private _elem: ElementRef, private _cdr: ChangeDetectorRef,
-    private _componentFactoryResolver: ComponentFactoryResolver, private _obsService: ScrollObservableService) {}
+    private _componentFactoryResolver: ComponentFactoryResolver, private _obsService: ScrollObservableService,
+    private _zone: NgZone) {}
 
   ngOnInit() {
     const getContainerRect = () => this._elem.nativeElement.getBoundingClientRect();
@@ -110,10 +112,16 @@ export class VirtualScrollComponent implements OnInit, OnDestroy {
       .startWith(getContainerRect())
       .map(({width, height}) => ({width, height}));
 
-    const scrollTop$ = Observable.fromEvent(this._elem.nativeElement, 'scroll')
-      .debounceTime(this.vsDebounceTime, animationScheduler)
-      .map(() => getScrollTop())
-      .startWith(0);
+    const scroll$ = new Subject<void>();
+    this._zone.runOutsideAngular(() => this._subs.push(
+        Observable.fromEvent(this._elem.nativeElement, 'scroll')
+            .debounceTime(this.vsDebounceTime, animationScheduler)
+            .subscribe(() => this._zone.run(() => scroll$.next())))
+        );
+
+    var /** @type {?} */ scrollTop$ = scroll$
+        .map(() => getScrollTop())
+        .startWith(0);
 
     const measure$ = Observable.combineLatest(rect$, options$)
       .map(([rect, options]) => calcMeasure(rect, options))

--- a/src/virtualScroll.component.ts
+++ b/src/virtualScroll.component.ts
@@ -119,7 +119,7 @@ export class VirtualScrollComponent implements OnInit, OnDestroy {
             .subscribe(() => this._zone.run(() => scroll$.next())))
         );
 
-    var /** @type {?} */ scrollTop$ = scroll$
+    const scrollTop$ = scroll$
         .map(() => getScrollTop())
         .startWith(0);
 

--- a/src/virtualScroll.component.ts
+++ b/src/virtualScroll.component.ts
@@ -113,15 +113,18 @@ export class VirtualScrollComponent implements OnInit, OnDestroy {
       .map(({width, height}) => ({width, height}));
 
     const scroll$ = new Subject<void>();
-    this._zone.runOutsideAngular(() => this._subs.push(
+    this._zone.runOutsideAngular(() => {
+      this._subs.push(
         Observable.fromEvent(this._elem.nativeElement, 'scroll')
-            .debounceTime(this.vsDebounceTime, animationScheduler)
-            .subscribe(() => this._zone.run(() => scroll$.next())))
-        );
+          .debounceTime(this.vsDebounceTime, animationScheduler)
+          .subscribe(() => {
+            this._zone.run(() => scroll$.next())
+          }))
+      });
 
     const scrollTop$ = scroll$
-        .map(() => getScrollTop())
-        .startWith(0);
+      .map(() => getScrollTop())
+      .startWith(0);
 
     const measure$ = Observable.combineLatest(rect$, options$)
       .map(([rect, options]) => calcMeasure(rect, options))


### PR DESCRIPTION
Hi Dinony,
We experience poor scrolling performance in IE even if we set vsDebounceTime to a large value. After some investigation we have discovered that Angular change detection is triggered on each 'scroll' event despite debounceTime(). This can be prevented by wrapping Observable.fromEvent(..., 'scroll') in zone.runOutsideAngular().
I couldn't figure out how to create a cold observable with Observable.fromEvent as if subscribe() is called outside of zone.runOutsideAngular() Angular change detection is still triggered on each scroll event. The proposed solution adds an intermediate scroll$ Subject.
Kind regards,
Serguei.