### PR TITLE
Variable item height

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ If you want to apply a traditional layout and wonder about the space between inl
 ```typescript
 export interface IVirtualScrollOptions {
   itemWidth?: number;
-  itemHeight: number;
+  itemHeight: number|Promise<number>|((item: any, i: number) => number|Promise<number>);
   numAdditionalRows?: number;
   numLimitColumns?: number;
 }
 ```
 
-The component requires either fixed-size cells (itemWidth, itemHeight) or a fixed number of cells per row (itemHeight, numLimitColumns).
+The component requires either fixed-size cells (itemWidth, itemHeight) or a fixed number of cells per row (itemHeight, numLimitColumns). When using a function for itemHeight, numLimitColumns must be set to exactly 1.
 
 Further, to improve scrolling, additional rows may be requested.
 

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -1,6 +1,8 @@
+export type ItemHeightFunction = (item: any, i: number) => number|Promise<number>;
+
 export interface IVirtualScrollOptions {
   itemWidth?: number;
-  itemHeight: number;
+  itemHeight: number|Promise<number>|ItemHeightFunction;
   numAdditionalRows?: number;
   numLimitColumns?: number;
 }
@@ -14,7 +16,8 @@ export interface IVirtualScrollMeasurement {
   containerWidth: number;
   containerHeight: number;
   itemWidth?: number;
-  itemHeight: number;
+  itemHeight: number|number[];
+  minItemHeight: number;
   numPossibleRows: number;
   numPossibleColumns: number;
   numPossibleItems: number;
@@ -25,11 +28,12 @@ export interface IVirtualScrollWindow {
   containerWidth: number;
   containerHeight: number;
   itemWidth?: number;
-  itemHeight: number;
+  itemHeight: number|number[];
   numVirtualItems: number;
   numVirtualRows: number;
   virtualHeight: number;
   numAdditionalRows: number;
+  rowShifts?: number[];
   scrollTop: number;
   scrollPercentage: number;
   numActualRows: number;

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -7,7 +7,7 @@ export async function calcMeasure(data: any[], rect: IVirtualScrollContainer, op
 
   const itemHeight = typeof options.itemHeight === 'number' ? options.itemHeight : await (typeof options.itemHeight !== 'function' ? options.itemHeight : Promise.all(data.map(async (item, i) => (<ItemHeightFunction> options.itemHeight)(item, i))));
 
-  const minItemHeight = typeof itemHeight === 'number' ? itemHeight : itemHeight.reduce((a, b) => Math.min(a, b));
+  const minItemHeight = typeof itemHeight === 'number' ? itemHeight : itemHeight.length === 0 ? 0 : itemHeight.reduce((a, b) => Math.min(a, b));
 
   const numPossibleRows = Math.ceil(rect.height / minItemHeight);
   const numPossibleColumns = options.itemWidth !== undefined ? Math.floor(rect.width / options.itemWidth) : 0;
@@ -33,12 +33,12 @@ export function calcScrollWindow(scrollTop: number, measure: IVirtualScrollMeasu
   const numActualColumns = Math.min(numVirtualItems, requestedColumns);
 
   const numVirtualRows = Math.ceil(numVirtualItems / Math.max(1, numActualColumns));
-  const virtualHeight = typeof measure.itemHeight === 'number' ? numVirtualRows * measure.itemHeight : measure.itemHeight.reduce((a, b) => a + b);
+  const virtualHeight = typeof measure.itemHeight === 'number' ? numVirtualRows * measure.itemHeight : measure.itemHeight.reduce((a, b) => a + b, 0);
   const numAdditionalRows = options.numAdditionalRows !== undefined ? options.numAdditionalRows : 1;
   const requestedRows = measure.numPossibleRows + numAdditionalRows;
   const numActualRows = numActualColumns > 0 ? Math.min(requestedRows, numVirtualRows) : 0;
 
-  const visibleStartRow = typeof measure.itemHeight === 'number' ? undefined : measure.itemHeight.reduce(
+  const visibleStartRow = typeof measure.itemHeight === 'number' ? undefined : Math.max(0, measure.itemHeight.reduce(
     (a, b, i) => {
       if (a >= 0) {
         return a;
@@ -48,9 +48,9 @@ export function calcScrollWindow(scrollTop: number, measure: IVirtualScrollMeasu
       return sum >= 0 ? i : sum;
     },
     -scrollTop
-  );
+  ));
 
-  const actualHeight = typeof measure.itemHeight === 'number' ? numActualRows * measure.itemHeight : typeof visibleStartRow === 'number' ? measure.itemHeight.slice(visibleStartRow).reduce((a, b) => a + b) : 0;
+  const actualHeight = typeof measure.itemHeight === 'number' ? numActualRows * measure.itemHeight : typeof visibleStartRow === 'number' ? measure.itemHeight.slice(visibleStartRow).reduce((a, b) => a + b, 0) : 0;
 
   const visibleEndRow = typeof measure.itemHeight === 'number' ? (numActualColumns > 0 && numActualRows > 0 ? clamp(0, numVirtualRows - 1, Math.floor((scrollTop + actualHeight) / measure.minItemHeight) - 1) : -1) : typeof visibleStartRow === 'number' ? (visibleStartRow + numActualRows - 1) : 0;
 

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -1,14 +1,23 @@
-import {IVirtualScrollContainer, IVirtualScrollMeasurement, IVirtualScrollOptions, IVirtualScrollWindow} from './basic';
+import {ItemHeightFunction, IVirtualScrollContainer, IVirtualScrollMeasurement, IVirtualScrollOptions, IVirtualScrollWindow} from './basic';
 
-export function calcMeasure(rect: IVirtualScrollContainer, options: IVirtualScrollOptions): IVirtualScrollMeasurement {
-  const numPossibleRows = Math.ceil(rect.height / options.itemHeight);
+export async function calcMeasure(data: any[], rect: IVirtualScrollContainer, options: IVirtualScrollOptions): Promise<IVirtualScrollMeasurement> {
+  if (typeof options.itemHeight === 'function' && options.numLimitColumns !== 1) {
+    throw new Error('numLimitColumns must equal 1 when using variable item height.');
+  }
+
+  const itemHeight = typeof options.itemHeight === 'number' ? options.itemHeight : await (typeof options.itemHeight !== 'function' ? options.itemHeight : Promise.all(data.map(async (item, i) => (<ItemHeightFunction> options.itemHeight)(item, i))));
+
+  const minItemHeight = typeof itemHeight === 'number' ? itemHeight : itemHeight.reduce((a, b) => Math.min(a, b));
+
+  const numPossibleRows = Math.ceil(rect.height / minItemHeight);
   const numPossibleColumns = options.itemWidth !== undefined ? Math.floor(rect.width / options.itemWidth) : 0;
 
   return {
     containerHeight: rect.height,
     containerWidth: rect.width,
-    itemHeight: options.itemHeight,
+    itemHeight,
     itemWidth: options.itemWidth,
+    minItemHeight,
     numPossibleColumns,
     numPossibleItems: numPossibleRows * numPossibleColumns,
     numPossibleRows,
@@ -24,14 +33,28 @@ export function calcScrollWindow(scrollTop: number, measure: IVirtualScrollMeasu
   const numActualColumns = Math.min(numVirtualItems, requestedColumns);
 
   const numVirtualRows = Math.ceil(numVirtualItems / Math.max(1, numActualColumns));
-  const virtualHeight = numVirtualRows * measure.itemHeight;
+  const virtualHeight = typeof measure.itemHeight === 'number' ? numVirtualRows * measure.itemHeight : measure.itemHeight.reduce((a, b) => a + b);
   const numAdditionalRows = options.numAdditionalRows !== undefined ? options.numAdditionalRows : 1;
   const requestedRows = measure.numPossibleRows + numAdditionalRows;
   const numActualRows = numActualColumns > 0 ? Math.min(requestedRows, numVirtualRows) : 0;
 
-  const actualHeight = numActualRows * measure.itemHeight;
+  const visibleStartRow = typeof measure.itemHeight === 'number' ? undefined : measure.itemHeight.reduce(
+    (a, b, i) => {
+      if (a >= 0) {
+        return a;
+      }
 
-  const visibleEndRow = numActualColumns > 0 && numActualRows > 0 ? clamp(0, numVirtualRows - 1, Math.floor((scrollTop + actualHeight) / measure.itemHeight) - 1) : -1;
+      const sum = a + b;
+      return sum >= 0 ? i : sum;
+    },
+    -scrollTop
+  );
+
+  const actualHeight = typeof measure.itemHeight === 'number' ? numActualRows * measure.itemHeight : typeof visibleStartRow === 'number' ? measure.itemHeight.slice(visibleStartRow).reduce((a, b) => a + b) : 0;
+
+  const visibleEndRow = typeof measure.itemHeight === 'number' ? (numActualColumns > 0 && numActualRows > 0 ? clamp(0, numVirtualRows - 1, Math.floor((scrollTop + actualHeight) / measure.minItemHeight) - 1) : -1) : typeof visibleStartRow === 'number' ? (visibleStartRow + numActualRows - 1) : 0;
+
+  const rowShifts = typeof measure.itemHeight === 'number' ? undefined : measure.itemHeight.reduce((arr, n) => arr.concat(arr[arr.length - 1] + n), [0]).slice(0, -1);
 
   return {
     actualHeight,
@@ -46,11 +69,12 @@ export function calcScrollWindow(scrollTop: number, measure: IVirtualScrollMeasu
     numAdditionalRows,
     numVirtualItems,
     numVirtualRows,
+    rowShifts,
     scrollPercentage: clamp(0, 100, scrollTop / (virtualHeight - measure.containerHeight)),
     scrollTop,
     virtualHeight,
     visibleEndRow,
-    visibleStartRow: visibleEndRow !== -1 ? Math.max(0, visibleEndRow - numActualRows + 1) : -1
+    visibleStartRow: typeof visibleStartRow === 'number' ? visibleStartRow : visibleEndRow !== -1 ? Math.max(0, visibleEndRow - numActualRows + 1) : -1
   };
 }
 

--- a/src/virtualScroll.component.ts
+++ b/src/virtualScroll.component.ts
@@ -91,7 +91,7 @@ export class VirtualScrollComponent implements OnInit, OnDestroy {
     private _elem: ElementRef, private _cdr: ChangeDetectorRef,
     private _componentFactoryResolver: ComponentFactoryResolver, private _obsService: ScrollObservableService) {}
 
-  async ngOnInit() {
+  ngOnInit() {
     const getContainerRect = () => this._elem.nativeElement.getBoundingClientRect();
 
     const getScrollTop = () => this._elem.nativeElement.scrollTop;


### PR DESCRIPTION
This is something that will help me out a lot right now, so I decided to quickly throw together a PR of the bare minimum functionality that I need.

Edit: Disregard all of the below. After way too much time debugging this, it turned out to be a minor issue with `dataTimestamp` and my introduction of async functions. Everything is working 100% as intended now!

---

~Unfortunately, I haven't been able to properly test it. The base case `itemHeight: 123` still works as expected, but adding any asynchronicity at all seems to break things. e.g. `itemHeight: Promise.resolve(123)` causes no list items to be rendered, except in one instance where it randomly worked. I'm guessing there's some sort of timing/concurrency issue here (maybe related to the connect order?), but not really sure since I haven't spent a lot of time investigating. Any ideas?~

~Testing issues / concurrency aside, does the approach I took here look like it makes sense?~

~Edit: Upon further testing, just `itemHeight: 123` actually pretty much consistently triggers the problem when Firefox is using really high CPU. I'm guessing that there's a pre-existing concurrency issue here somewhere and my changes just made it more apparent.~